### PR TITLE
Add a skip ahead stream reader

### DIFF
--- a/client.go
+++ b/client.go
@@ -127,6 +127,17 @@ func (c *Client) NewStreamReader(streamName string) *StreamReader {
 	}
 }
 
+// NewPagedStreamReader returns a new *StreamReader that jumps to a designated page
+func (c *Client) NewPagedStreamReader(streamName string, page int, lastEventNumber int) *StreamReader {
+	return &StreamReader{
+		streamName:  streamName,
+		client:      c,
+		version:     lastEventNumber,
+		nextVersion: lastEventNumber + 1,
+		pageSize:    page,
+	}
+}
+
 // NewStreamWriter returns a new *StreamWriter.
 func (c *Client) NewStreamWriter(streamName string) *StreamWriter {
 	return &StreamWriter{

--- a/errors.go
+++ b/errors.go
@@ -29,7 +29,7 @@ type ErrDeleted struct {
 }
 
 func (e ErrDeleted) Error() string {
-	return "The stream has was deleted."
+	return "The stream has been deleted."
 }
 
 // ErrUnauthorized is returned when a request to the eventstore is

--- a/streamreader.go
+++ b/streamreader.go
@@ -122,7 +122,6 @@ func (s *StreamReader) Next() bool {
 	e, _, err := s.client.GetEvent(url)
 	if err != nil {
 		s.lasterr = err
-		return true
 	}
 	s.eventResponse = e
 	s.version = s.nextVersion


### PR DESCRIPTION
There are times when we need to "continue" a stream reader for a certain given point. It can be helpful in the case of catch-up subscriptions or to pause/unpause reader.